### PR TITLE
Move command.go to subpkg to fix build breakage on darwin

### DIFF
--- a/common/command/command.go
+++ b/common/command/command.go
@@ -1,4 +1,4 @@
-package common
+package command
 
 import (
 	"os"
@@ -40,7 +40,7 @@ func GetGroupId(groupName string) (int, error) {
 	return strconv.Atoi(g.Gid)
 }
 
-func NewCommand(bin string, args []string, user, group string) (*Command, error) {
+func New(bin string, args []string, user, group string) (*Command, error) {
 	c := &Command{
 		Bin:   bin,
 		Args:  args,

--- a/executor/metrics/metrics.go
+++ b/executor/metrics/metrics.go
@@ -1,7 +1,7 @@
 package metrics
 
 import (
-	"github.com/percona/dcos-mongo-tools/common"
+	"github.com/percona/dcos-mongo-tools/common/command"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -40,7 +40,7 @@ func (m *Metrics) Run() error {
 		return nil
 	}
 
-	cmd, err := common.NewCommand(
+	cmd, err := command.New(
 		m.config.MgoStatsdBin,
 		[]string{
 			"-configUpdateInterval", mgoStatsdConfigUpdateInterval,

--- a/executor/mongodb/mongod.go
+++ b/executor/mongodb/mongod.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/percona/dcos-mongo-tools/common"
+	"github.com/percona/dcos-mongo-tools/common/command"
 	log "github.com/sirupsen/logrus"
 	mongo_config "github.com/timvaillancourt/go-mongodb-config/config"
 )
@@ -19,7 +19,7 @@ type Mongod struct {
 	config     *Config
 	configFile string
 	commandBin string
-	command    *common.Command
+	command    *command.Command
 }
 
 func NewMongod(config *Config, nodeType string) *Mongod {
@@ -45,13 +45,13 @@ func mkdir(path string, uid int, gid int, mode os.FileMode) error {
 }
 
 func (m *Mongod) Initiate() error {
-	uid, err := common.GetUserId(m.config.User)
+	uid, err := command.GetUserId(m.config.User)
 	if err != nil {
 		log.Errorf("Could not get user %s UID: %s\n", m.config.User, err)
 		return err
 	}
 
-	gid, err := common.GetGroupId(m.config.Group)
+	gid, err := command.GetGroupId(m.config.Group)
 	if err != nil {
 		log.Errorf("Could not get group %s GID: %s\n", m.config.Group, err)
 		return err
@@ -114,7 +114,7 @@ func (m *Mongod) Start() error {
 		return err
 	}
 
-	m.command, err = common.NewCommand(
+	m.command, err = command.New(
 		m.commandBin,
 		[]string{"--config", m.configFile},
 		m.config.User,

--- a/executor/pmm/service.go
+++ b/executor/pmm/service.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/percona/dcos-mongo-tools/common"
+	"github.com/percona/dcos-mongo-tools/common/command"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -42,7 +42,7 @@ func (s *Service) Add() error {
 	}
 	args = append(args, s.Args...)
 
-	cmd, err := common.NewCommand(
+	cmd, err := command.New(
 		pmmAdminCommand,
 		args,
 		pmmAdminRunUser,
@@ -81,7 +81,7 @@ func (s *Service) AddWithRetry(maxRetries uint, retrySleep time.Duration) error 
 func (p *PMM) Repair() error {
 	log.Info("Repairing all PMM client services")
 
-	cmd, err := common.NewCommand(
+	cmd, err := command.New(
 		pmmAdminCommand,
 		[]string{"repair", "--config-file=" + p.configFile},
 		pmmAdminRunUser,


### PR DESCRIPTION
common/command.go is causing build failures in the DCOS CLI program for Darwin/OSX, a program which imports "common".

```
unknown field 'Credential' in struct literal of type syscall.SysProcAttr
```

This is due to system-specific differences with Darwin. As the CLI does not need anything from common/command.go I have made command.go it's own sub-package of common.