### PR TITLE
Use busybox for final docker FROM (to save space)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM alpine:3.7
+FROM busybox:1.27
 COPY bin/mongodb-controller-* /usr/bin/
 COPY bin/mongodb-watchdog-* /usr/bin/


### PR DESCRIPTION
After the go binaries are compiled we don't need alpine anymore. Plain-Busybox (what Alpine is based on) uses 16% less space.