### PR TITLE
 Set wiredTiger cache size based on Docker container limits

### DIFF
--- a/cmd/mongodb-executor/main.go
+++ b/cmd/mongodb-executor/main.go
@@ -62,6 +62,10 @@ func handleMongoDB(app *kingpin.Application, cnf *config.Config) {
 		"mongodb.group",
 		"group to run mongodb instance as",
 	).Default(mongodb.DefaultGroup).StringVar(&cnf.MongoDB.Group)
+	app.Flag(
+		"mongodb.wiredTigerCacheRatio",
+		"the ratio of system memory to be used for wiredTiger cache",
+	).Default(mongodb.DefaultWiredTigerCacheRatio).Float64Var(&cnf.MongoDB.WiredTigerCacheRatio)
 }
 
 func handleMetrics(app *kingpin.Application, cnf *config.Config) {

--- a/executor/mongodb/config.go
+++ b/executor/mongodb/config.go
@@ -15,17 +15,19 @@
 package mongodb
 
 const (
-	DefaultBinDir            = "/usr/bin"
-	DefaultTmpDirFallback    = "/tmp"
-	DefaultConfigDirFallback = "/etc"
-	DefaultUser              = "mongodb"
-	DefaultGroup             = "root"
+	DefaultBinDir               = "/usr/bin"
+	DefaultTmpDirFallback       = "/tmp"
+	DefaultConfigDirFallback    = "/etc"
+	DefaultUser                 = "mongodb"
+	DefaultGroup                = "root"
+	DefaultWiredTigerCacheRatio = "0.5"
 )
 
 type Config struct {
-	ConfigDir string
-	BinDir    string
-	TmpDir    string
-	User      string
-	Group     string
+	ConfigDir            string
+	BinDir               string
+	TmpDir               string
+	User                 string
+	Group                string
+	WiredTigerCacheRatio float64
 }

--- a/executor/mongodb/mongod.go
+++ b/executor/mongodb/mongod.go
@@ -92,11 +92,7 @@ func NewMongod(config *Config) *Mongod {
 //
 // https://docs.mongodb.com/manual/reference/configuration-options/#storage.wiredTiger.engineConfig.cacheSizeGB
 //
-func (m *Mongod) getWiredTigerCacheSizeGB() float64 {
-	limitBytes := getMemoryLimitBytes()
-	if limitBytes < 1 {
-		return 0
-	}
+func (m *Mongod) getWiredTigerCacheSizeGB(limitBytes int64) float64 {
 	size := math.Floor(m.config.WiredTigerCacheRatio * (float64(limitBytes) - gigaByte))
 	sizeGB := size / gigaByte
 	if sizeGB < minWiredTigerCacheSizeGB {
@@ -135,8 +131,9 @@ func (m *Mongod) Initiate() error {
 	}
 
 	if config.Storage.Engine == "wiredTiger" {
-		cacheSizeGB := m.getWiredTigerCacheSizeGB()
-		if cacheSizeGB > 0 {
+		limitBytes := getMemoryLimitBytes()
+		if limitBytes > 0 {
+			cacheSizeGB := m.getWiredTigerCacheSizeGB(limitBytes)
 			log.WithFields(log.Fields{
 				"size_gb": cacheSizeGB,
 				"ratio":   m.config.WiredTigerCacheRatio,

--- a/executor/mongodb/mongod_test.go
+++ b/executor/mongodb/mongod_test.go
@@ -53,13 +53,27 @@ func TestExecutorMongoDBGetWiredTigerCacheSizeGB(t *gotesting.T) {
 }
 
 func TestExecutorMongoDBGetMemoryLimitBytes(t *gotesting.T) {
+	var err error
+
+	// does not exist
+	assert.Equal(t, int64(0), getMemoryLimitBytes("/does/not/exist"))
+
+	// test that .getMemoryLimitBytes() returns 0 if the memory limit
+	// is equal to the noMemoryLimit const
 	limitFile, _ := ioutil.TempFile("", t.Name())
 	defer os.Remove(limitFile.Name())
-	data := []byte(strconv.Itoa(int(gigaByte)))
-	_, err := limitFile.Write(data)
+	data := []byte(strconv.Itoa(int(noMemoryLimit)))
+	_, err = limitFile.Write(data)
 	assert.NoError(t, err)
-	assert.Equal(t, int64(gigaByte), getMemoryLimitBytes(limitFile.Name()))
-	assert.Equal(t, int64(0), getMemoryLimitBytes("/does/not/exist"))
+	assert.Equal(t, int64(0), getMemoryLimitBytes(limitFile.Name()))
+
+	// check we can write and read successfully
+	limitFile2, _ := ioutil.TempFile("", t.Name())
+	defer os.Remove(limitFile2.Name())
+	data2 := []byte(strconv.Itoa(int(gigaByte)))
+	_, err = limitFile2.Write(data2)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(gigaByte), getMemoryLimitBytes(limitFile2.Name()))
 }
 
 func TestExecutorMongoDBMkdir(t *gotesting.T) {

--- a/executor/mongodb/mongod_test.go
+++ b/executor/mongodb/mongod_test.go
@@ -53,12 +53,9 @@ func TestExecutorMongoDBGetWiredTigerCacheSizeGB(t *gotesting.T) {
 }
 
 func TestExecutorMongoDBGetMemoryLimitBytes(t *gotesting.T) {
-	var err error
-
 	// does not exist
-	limit, err := getMemoryLimitBytes("/does/not/exist")
+	_, err := getMemoryLimitBytes("/does/not/exist")
 	assert.Error(t, err)
-	assert.Equal(t, int64(0), limit)
 
 	// test that .getMemoryLimitBytes() returns 0 (and no error)
 	// if the memory limit is equal to the noMemoryLimit const
@@ -67,9 +64,8 @@ func TestExecutorMongoDBGetMemoryLimitBytes(t *gotesting.T) {
 	data := []byte(strconv.Itoa(int(noMemoryLimit)))
 	_, err = limitFile.Write(data)
 	assert.NoError(t, err)
-	limit, err = getMemoryLimitBytes(limitFile.Name())
+	_, err = getMemoryLimitBytes(limitFile.Name())
 	assert.NoError(t, err)
-	assert.Equal(t, int64(0), limit)
 
 	// check we can write and read successfully without error
 	limitFile2, _ := ioutil.TempFile("", t.Name())
@@ -77,7 +73,7 @@ func TestExecutorMongoDBGetMemoryLimitBytes(t *gotesting.T) {
 	data2 := []byte(strconv.Itoa(int(gigaByte)))
 	_, err = limitFile2.Write(data2)
 	assert.NoError(t, err)
-	limit, err = getMemoryLimitBytes(limitFile2.Name())
+	limit, err := getMemoryLimitBytes(limitFile2.Name())
 	assert.NoError(t, err)
 	assert.Equal(t, int64(gigaByte), limit)
 }

--- a/executor/mongodb/mongod_test.go
+++ b/executor/mongodb/mongod_test.go
@@ -56,24 +56,30 @@ func TestExecutorMongoDBGetMemoryLimitBytes(t *gotesting.T) {
 	var err error
 
 	// does not exist
-	assert.Equal(t, int64(0), getMemoryLimitBytes("/does/not/exist"))
+	limit, err := getMemoryLimitBytes("/does/not/exist")
+	assert.Error(t, err)
+	assert.Equal(t, int64(0), limit)
 
-	// test that .getMemoryLimitBytes() returns 0 if the memory limit
-	// is equal to the noMemoryLimit const
+	// test that .getMemoryLimitBytes() returns 0 (and no error)
+	// if the memory limit is equal to the noMemoryLimit const
 	limitFile, _ := ioutil.TempFile("", t.Name())
 	defer os.Remove(limitFile.Name())
 	data := []byte(strconv.Itoa(int(noMemoryLimit)))
 	_, err = limitFile.Write(data)
 	assert.NoError(t, err)
-	assert.Equal(t, int64(0), getMemoryLimitBytes(limitFile.Name()))
+	limit, err = getMemoryLimitBytes(limitFile.Name())
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), limit)
 
-	// check we can write and read successfully
+	// check we can write and read successfully without error
 	limitFile2, _ := ioutil.TempFile("", t.Name())
 	defer os.Remove(limitFile2.Name())
 	data2 := []byte(strconv.Itoa(int(gigaByte)))
 	_, err = limitFile2.Write(data2)
 	assert.NoError(t, err)
-	assert.Equal(t, int64(gigaByte), getMemoryLimitBytes(limitFile2.Name()))
+	limit, err = getMemoryLimitBytes(limitFile2.Name())
+	assert.NoError(t, err)
+	assert.Equal(t, int64(gigaByte), limit)
 }
 
 func TestExecutorMongoDBMkdir(t *gotesting.T) {

--- a/executor/mongodb/mongod_test.go
+++ b/executor/mongodb/mongod_test.go
@@ -42,6 +42,16 @@ func TestExecutorMongoDBNewMongod(t *gotesting.T) {
 	assert.Contains(t, testMongod.configFile, testConfig.ConfigDir)
 }
 
+func TestExecutorMongoDBGetWiredTigerCacheSizeGB(t *gotesting.T) {
+	mongod := &Mongod{
+		config: &Config{WiredTigerCacheRatio: 0.5},
+	}
+	assert.Equal(t, minWiredTigerCacheSizeGB, mongod.getWiredTigerCacheSizeGB(int64(1*gigaByte)))
+	assert.Equal(t, 1.5, mongod.getWiredTigerCacheSizeGB(int64(4*gigaByte)))
+	assert.Equal(t, 31.5, mongod.getWiredTigerCacheSizeGB(int64(64*gigaByte)))
+	assert.Equal(t, 63.5, mongod.getWiredTigerCacheSizeGB(int64(128*gigaByte)))
+}
+
 func TestExecutorMongoDBMkdir(t *gotesting.T) {
 	dir, _ := ioutil.TempDir("", "TestExecutorMongoDBMkdir")
 	os.RemoveAll(dir)

--- a/executor/mongodb/mongod_test.go
+++ b/executor/mongodb/mongod_test.go
@@ -42,6 +42,8 @@ func TestExecutorMongoDBNewMongod(t *gotesting.T) {
 	assert.Contains(t, testMongod.configFile, testConfig.ConfigDir)
 }
 
+// Test .getWiredTigerCacheSizeGB() mimics the cache-sizing logic described in the documentation:
+// https://docs.mongodb.com/manual/reference/configuration-options/#storage.wiredTiger.engineConfig.cacheSizeGB
 func TestExecutorMongoDBGetWiredTigerCacheSizeGB(t *gotesting.T) {
 	mongod := &Mongod{
 		config: &Config{WiredTigerCacheRatio: 0.5},

--- a/executor/mongodb/mongod_test.go
+++ b/executor/mongodb/mongod_test.go
@@ -61,7 +61,7 @@ func TestExecutorMongoDBGetMemoryLimitBytes(t *gotesting.T) {
 	// if the memory limit is equal to the noMemoryLimit const
 	limitFile, _ := ioutil.TempFile("", t.Name())
 	defer os.Remove(limitFile.Name())
-	data := []byte(strconv.Itoa(int(noMemoryLimit)))
+	data := []byte(strconv.Itoa(int(noMemoryLimit)) + "\n")
 	_, err = limitFile.Write(data)
 	assert.NoError(t, err)
 	_, err = getMemoryLimitBytes(limitFile.Name())
@@ -70,7 +70,7 @@ func TestExecutorMongoDBGetMemoryLimitBytes(t *gotesting.T) {
 	// check we can write and read successfully without error
 	limitFile2, _ := ioutil.TempFile("", t.Name())
 	defer os.Remove(limitFile2.Name())
-	data2 := []byte(strconv.Itoa(int(gigaByte)))
+	data2 := []byte(strconv.Itoa(int(gigaByte)) + "\n")
 	_, err = limitFile2.Write(data2)
 	assert.NoError(t, err)
 	limit, err := getMemoryLimitBytes(limitFile2.Name())

--- a/executor/mongodb/mongod_test.go
+++ b/executor/mongodb/mongod_test.go
@@ -52,6 +52,16 @@ func TestExecutorMongoDBGetWiredTigerCacheSizeGB(t *gotesting.T) {
 	assert.Equal(t, 63.5, mongod.getWiredTigerCacheSizeGB(int64(128*gigaByte)))
 }
 
+func TestExecutorMongoDBGetMemoryLimitBytes(t *gotesting.T) {
+	limitFile, _ := ioutil.TempFile("", t.Name())
+	defer os.Remove(limitFile.Name())
+	data := []byte(strconv.Itoa(int(gigaByte)))
+	_, err := limitFile.Write(data)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(gigaByte), getMemoryLimitBytes(limitFile.Name()))
+	assert.Equal(t, int64(0), getMemoryLimitBytes("/does/not/exist"))
+}
+
 func TestExecutorMongoDBMkdir(t *gotesting.T) {
 	dir, _ := ioutil.TempDir("", "TestExecutorMongoDBMkdir")
 	os.RemoveAll(dir)

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 5fd4883af184467b89eac84f29b4638a5263ffbc223ea2dd6be057abc2b566d3
-updated: 2018-07-20T14:37:24.538218457+02:00
+updated: 2018-08-29T19:15:14.019637525+02:00
 imports:
 - name: github.com/alecthomas/kingpin
   version: a39589180ebd6bbf43076e514b55f20a95d43086
@@ -21,16 +21,20 @@ imports:
   version: 8991bc29aa16c548c550c7ff78260e27b9ab7c73
   subpackages:
   - spew
+- name: github.com/gogo/protobuf
+  version: 3e657e582e841bf7cabdb3e28280e90b350b94f1
+  subpackages:
+  - proto
 - name: github.com/golang/mock
-  version: 22bbf0ddf08105dfa364d0a2fa619dfa71014af5
+  version: 600781dde9cca80734169b9e969d9054ccc57937
   subpackages:
   - gomock
 - name: github.com/golang/protobuf
-  version: 14aad3d5ea4c323bcd7a2137e735da24a76e814c
+  version: b27b920f9e71b439b873b17bf99f56467623814a
   subpackages:
   - proto
 - name: github.com/klauspost/compress
-  version: b939724e787a27c0005cabe3f78e7ed7987ac74f
+  version: b50017755d442260d792c34c7c43216d9ba7ffc7
   subpackages:
   - flate
   - gzip
@@ -50,7 +54,7 @@ imports:
   subpackages:
   - difflib
 - name: github.com/prometheus/client_golang
-  version: bcbbc08eb2ddff3af83bbf11e7ec13b4fd730b6e
+  version: 676eaf6b948046fcd9dbbcf5cc9ff5077921aa81
   subpackages:
   - prometheus
   - prometheus/promhttp
@@ -59,13 +63,13 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 7600349dcfe1abd18d72d3a1770870d9800a7801
+  version: c7de2306084e37d54b8be01f3541a8464345e9a5
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: ae68e2d4c00fed4943b5f6698d504a5fe083da8a
+  version: 05ee40e3a273f7245e8777337fc7b46e533a9a92
   subpackages:
   - internal/util
   - nfs
@@ -78,16 +82,16 @@ imports:
   subpackages:
   - .
 - name: github.com/sirupsen/logrus
-  version: a1f2e46d92096f9157fe71165f6f135d9f0b9c18
+  version: 51df1d314861d341546c26e4354ce760fe4bb02b
 - name: github.com/stretchr/objx
-  version: b8b73a35e9830ae509858c10dec5866b4d5c8bff
+  version: ef50b0de28773081167c97fc27cf29a0bf8b8c71
 - name: github.com/stretchr/testify
   version: f35b8ab0b5a2cef36673838d662e249dd9c94686
   subpackages:
   - assert
   - mock
 - name: github.com/timvaillancourt/go-mongodb-config
-  version: 35160f1fd66597e2cc988e89c3679900bd60d788
+  version: 5a5cc09294194d910bfc30033fed3a82cb798cf1
   subpackages:
   - config
 - name: github.com/timvaillancourt/go-mongodb-replset
@@ -98,22 +102,22 @@ imports:
 - name: github.com/valyala/bytebufferpool
   version: e746df99fe4a3986f4d4f79e13c1e0117ce9c2f7
 - name: github.com/valyala/fasthttp
-  version: e5f51c11919d4f66400334047b897ef0a94c6f3c
+  version: 373357d2d47d78c16c72ac4de4046da33585239c
   subpackages:
   - fasthttputil
   - stackless
 - name: github.com/vharitonsky/iniflags
   version: a33cd0b5f3de9ef5e89c90ab2f1ebe3f71ad1ece
 - name: golang.org/x/crypto
-  version: a2144134853fc9a27a7b1e3eb4f19f1a76df13c9
+  version: 614d502a4dac94afa3a6ce146bd1736da82514c6
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net
-  version: a680a1efc54dd51c040b3b5ce4939ea3cf2ea0d1
+  version: 8a410e7b638dca158bf9e766925842f6651ff828
   subpackages:
   - context
 - name: golang.org/x/sys
-  version: ac767d655b305d4e9612f5f6e33120b9176c4ad4
+  version: d99a578cf41bfccdeaf48b0845c823a4b8b0ad5e
   subpackages:
   - unix
   - windows


### PR DESCRIPTION
This is a fix to resolve https://github.com/mesosphere/dcos-mongo/issues/250.