### PR TITLE
delete cluster service dns suffix

### DIFF
--- a/pkg/pod/k8s/task.go
+++ b/pkg/pod/k8s/task.go
@@ -29,11 +29,10 @@ const (
 	mongodBackupContainerName  = "mongod-backup"
 	mongosContainerName        = "mongos"
 	mongodbPortName            = "mongodb"
-	clusterServiceDNSSuffix    = "svc.cluster.local"
 )
 
 func GetMongoHost(pod, service, replset, namespace string) string {
-	return strings.Join([]string{pod, service + "-" + replset, namespace, clusterServiceDNSSuffix}, ".")
+	return strings.Join([]string{pod, service + "-" + replset, namespace}, ".")
 }
 
 type TaskState struct {


### PR DESCRIPTION
User-defined cluster domain name suffix, mongodb will fail to create.